### PR TITLE
Bump ibrowse dependency, update instructions for Phoenix 0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Set as a dep in your mix.exs and ensure it is running with your app:
       {:phoenix, "0.5.0"},
       {:cowboy, "~> 1.0.0"},
       #...
-      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.0"},
-      {:exrecaptcha, "~> 0.0.3"}
+      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
+      {:exrecaptcha, "~> 0.0.4"}
     ]
   end
 ```
@@ -89,6 +89,7 @@ end
 
 ## Changelog
 
+- 0.0.4: Update ibrowse dependency, to build under R18
 - 0.0.3: Update HTTPotion dependency, avoiding elixir version warnings
 - 0.0.2: Use HTTPS by default
 - 0.0.1: Initial release

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Set as a dep in your mix.exs and ensure it is running with your app:
 
   defp deps do
     [
-      {:phoenix, "0.5.0"},
+      {:phoenix, "~> 0.17"},
       {:cowboy, "~> 1.0.0"},
       #...
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
@@ -56,11 +56,11 @@ You can use https instead of http for the `verify_url`.
 Put this code somewhere in your html template:
 
 ```html
-<form id="loginForm" name="newuser" method="post" action="/users">
+<%= form_for @conn, user_path(@conn, :create), [name: :register], fn f -> %>
   ...
-  <%= safe Exrecaptcha.display %>
+  <%= raw Exrecaptcha.display %>
   ...
-</form>
+<% end %>
 ```
 
 ### Controller

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Set as a dep in your mix.exs and ensure it is running with your app:
       {:cowboy, "~> 1.0.0"},
       #...
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
-      {:exrecaptcha, "~> 0.0.4"}
+      {:exrecaptcha, "~> 0.0.5"}
     ]
   end
 ```
@@ -56,7 +56,7 @@ You can use https instead of http for the `verify_url`.
 Put this code somewhere in your html template:
 
 ```html
-<%= form_for @conn, user_path(@conn, :create), [name: :register], fn f -> %>
+<%= form_for @conn, "/users", [name: :recaptcha], fn f -> %>
   ...
   <%= raw Exrecaptcha.display %>
   ...
@@ -85,10 +85,11 @@ end
 
 - No option for recaptcha display can be set yet
 - Error handling is quite inexistent (throws RuntimeError)
-- No tests
+- Support Recaptcha Version 2.0
 
 ## Changelog
 
+- 0.0.5: Update HTTPotion, Add tests
 - 0.0.4: Update ibrowse dependency, to build under R18
 - 0.0.3: Update HTTPotion dependency, avoiding elixir version warnings
 - 0.0.2: Use HTTPS by default

--- a/lib/exrecaptcha.ex
+++ b/lib/exrecaptcha.ex
@@ -16,10 +16,14 @@ defmodule Exrecaptcha do
                                "remoteip" => to_string(remote_ip),
                                "challenge" => challenge,
                                "response" => response})
-    IO.inspect query
+
     headers = ["Content-type": "application/x-www-form-urlencoded",
                "User-agent": "reCAPTCHA Elixir"]
-    %{:body => body} = HTTPotion.post conf.verify_url, query, headers
+    request_url = conf.verify_url <> "?" <> query
+
+    response = HTTPotion.post request_url, [headers: headers]
+    %{:body => body} = response
+
     check_result String.split(body)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Exrecaptcha.Mixfile do
 
   def project do
     [app: :exrecaptcha,
-     version: "0.0.4",
+     version: "0.0.5",
      elixir: "~> 1.0.0",
      description: description,
      deps: deps,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Exrecaptcha.Mixfile do
 
   def project do
     [app: :exrecaptcha,
-     version: "0.0.3",
+     version: "0.0.4",
      elixir: "~> 1.0.0",
      description: description,
      deps: deps,
@@ -23,7 +23,7 @@ defmodule Exrecaptcha.Mixfile do
 
   defp deps do
     [
-      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.0"},
+      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
       {:httpotion, "~> 1.0.0"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Exrecaptcha.Mixfile do
   defp deps do
     [
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
-      {:httpotion, "~> 1.0.0"}
+      {:httpotion, "~> 2.1"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Exrecaptcha.Mixfile do
 
   defp deps do
     [
+      {:exvcr, "~> 0.5", only: [:test]},
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
       {:httpotion, "~> 2.1"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"httpotion": {:hex, :httpotion, "1.0.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "7871e2ebe8811efb64e1917e2de455fa87e8dfe3", [tag: "v4.1.0"]}}
+  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"httpotion": {:hex, :httpotion, "1.0.0"},
+%{"httpotion": {:hex, :httpotion, "2.1.0"},
   "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,7 @@
-%{"httpotion": {:hex, :httpotion, "2.1.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}
+%{"exactor": {:hex, :exactor, "2.1.2"},
+  "exjsx": {:hex, :exjsx, "3.2.0"},
+  "exvcr": {:hex, :exvcr, "0.5.0"},
+  "httpotion": {:hex, :httpotion, "2.1.0"},
+  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
+  "jsx": {:hex, :jsx, "2.6.2"},
+  "meck": {:hex, :meck, "0.8.3"}}

--- a/test/exrecaptcha_test.exs
+++ b/test/exrecaptcha_test.exs
@@ -1,7 +1,44 @@
 defmodule ExrecaptchaTest do
   use ExUnit.Case
+  use ExVCR.Mock
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "verify returns :ok if sent successfully" do
+
+    remote_ip = {127, 0, 0, 0}
+    challenge = "CHALLENGE"
+    response = "RESPONSE"
+
+    request_url = "http://www.google.com/recaptcha/api/verify?challenge=CHALLENGE&privatekey=YOUR_PRIVATE_KEY&remoteip=127.0.0.0&response=RESPONSE"
+    response_body = "true\nsuccess"
+
+    use_cassette :stub, [url: request_url,
+                         method: "post",
+                         status_code: 200,
+                         body: response_body] do
+
+      success = Exrecaptcha.verify(remote_ip, challenge, response)
+      assert :ok = success
+    end
   end
+
+  test "verify raises error if sent unsuccessfully" do
+
+    remote_ip = {127, 0, 0, 0}
+    challenge = "CHALLENGE"
+    response = "RESPONSE"
+
+    request_url = "http://www.google.com/recaptcha/api/verify?challenge=CHALLENGE&privatekey=YOUR_PRIVATE_KEY&remoteip=127.0.0.0&response=RESPONSE"
+    response_body = "false\nincorrect-captcha-sol"
+
+    use_cassette :stub, [url: request_url,
+                         method: "post",
+                         status_code: 200,
+                         body: response_body] do
+
+      assert_raise RuntimeError, "incorrect-captcha-sol", fn ->
+        Exrecaptcha.verify(remote_ip, challenge, response)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
I had to update ibrowse, otherwise it won't compile on Erlang 18 without an error/warning (see https://github.com/cmullaparthi/ibrowse/issues/129).

I also revised the README instructions for Phoenix 0.17.
